### PR TITLE
Add support for local references and configurable read simulator arguments

### DIFF
--- a/conf/params.config
+++ b/conf/params.config
@@ -55,5 +55,9 @@ params {
     paired = null
     unpaired = null
 
+    // Read simulator params (default settings provided)
+    badread_args = "--length 15000,13000 --identity 95,99,2.5 --error_model nanopore2023 --qscore_model nanopore2023 --junk_reads 1 --random_reads 1 --chimeras 1 --glitches 10000,25,25"
+    wgsim_args = "-1 150 -2 150 -r 0.001 -R 0.15"
+    
 
 }

--- a/conf/params.config
+++ b/conf/params.config
@@ -55,9 +55,31 @@ params {
     paired = null
     unpaired = null
 
-    // Read simulator params (default settings provided)
-    badread_args = "--length 15000,13000 --identity 95,99,2.5 --error_model nanopore2023 --qscore_model nanopore2023 --junk_reads 1 --random_reads 1 --chimeras 1 --glitches 10000,25,25"
-    wgsim_args = "-1 150 -2 150 -r 0.001 -R 0.15"
-    
+    // Bad read parameters - refer to badread docs for explanations of each - default settiings provided
+    // --length
+    badread_length = "15000,13000"
+    // --identity
+    badread_identity = "95,99,2.5"
+    // --error_model
+    badread_error_model = "nanopore2023"
+    // --qscore_model
+    badread_qscore_model = "nanopore2023"
+    // --junk_reads
+    badread_junk_reads = "1"
+    // --random_reads
+    badread_random_reads = "1"
+    // --chimeras
+    badread_chimeras = "1"
+    // --glitches
+    badread_glitches = "10000,25,25"
 
+    //wgsim parameters - refer to wgsims docs for detailed explanation
+    // -1
+    wgsim_length_read1 = "150"
+    // -2
+    wgsim_length_read2 = "150"
+    // -r
+    wgsim_mutation_rate = "0.001"
+    // -R
+    wgsim_indel_fraction = "0.15"
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,7 +20,7 @@ manifest {
     description     = 'Generate synthetic spiked-in metagenomic datasets.'
     mainScript      = 'main.nf'
     nextflowVersion = '>=20.10.0'
-    version         = 'v0.2.0'
+    version         = 'v0.3.0'
 }
 
 profiles {

--- a/subworkflows/simulate_datasets.nf
+++ b/subworkflows/simulate_datasets.nf
@@ -50,7 +50,7 @@ process simulate_reads {
     simulator = params.lookup["${platform}"]
     if ("${simulator}" == "badread") {
         """
-        badread simulate --reference ${ref_fasta} --quantity ${ref_coverage}x > ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads.fq
+        badread simulate --reference ${ref_fasta} --quantity ${ref_coverage}x ${params.badread_args} > ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads.fq
         gzip ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads.fq
         """
     } else {
@@ -75,7 +75,7 @@ process simulate_reads_paired {
         genome_length=\$(cat ${ref_fasta} | wc -c)
         num_reads=\$(echo "\$genome_length*${ref_coverage}/300" | bc)
         echo "\$genome_length \$num_reads"
-        wgsim -N \$num_reads -1 150 -2 150 -r 0.001 -R 0.15 ${ref_fasta} ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_1.fq ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_2.fq
+        wgsim -N \$num_reads ${params.wgsim_args} ${ref_fasta} ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_1.fq ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_2.fq
         gzip ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_1.fq ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_2.fq
         """
     } else {

--- a/subworkflows/simulate_datasets.nf
+++ b/subworkflows/simulate_datasets.nf
@@ -50,7 +50,17 @@ process simulate_reads {
     simulator = params.lookup["${platform}"]
     if ("${simulator}" == "badread") {
         """
-        badread simulate --reference ${ref_fasta} --quantity ${ref_coverage}x ${params.badread_args} > ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads.fq
+        badread simulate --reference ${ref_fasta} --quantity ${ref_coverage}x \
+        --length ${params.badread_length} \
+        --identity ${params.badread_identity} \
+        --error_model ${params.badread_error_model} \
+        --qscore_model ${params.badread_qscore_model} \
+        --junk_reads ${params.badread_junk_reads} \
+        --random_reads ${params.badread_random_reads} \
+        --chimeras ${params.badread_chimeras} \
+        --glitches ${params.badread_glitches} \
+        > ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads.fq
+        
         gzip ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads.fq
         """
     } else {
@@ -75,7 +85,15 @@ process simulate_reads_paired {
         genome_length=\$(cat ${ref_fasta} | wc -c)
         num_reads=\$(echo "\$genome_length*${ref_coverage}/300" | bc)
         echo "\$genome_length \$num_reads"
-        wgsim -N \$num_reads ${params.wgsim_args} ${ref_fasta} ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_1.fq ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_2.fq
+        wgsim \
+        -N \$num_reads \
+        -1 ${params.wgsim_length_read1} \
+        -2 ${params.wgsim_length_read2} \
+        -r ${params.wgsim_mutation_rate} \
+        -R ${params.wgsim_indel_fraction} \
+        ${ref_fasta} \
+        ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_1.fq \
+        ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_2.fq
         gzip ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_1.fq ${ref_accession}_${index}_${simulator}_${ref_coverage}x_reads_2.fq
         """
     } else {


### PR DESCRIPTION
Hello!
This PR adds 2 features:

### 1. Allows the user to supply a local fasta file in the reference_csv file.
 
  This works by utilising the existing `path` field supplied in the input `--reference_csv` file. If a value is present in the `path` field it will attempt to use it as a file path and skip the download. If left blank the default behaviour of downloading via ncbi datasets applies. This way you can mix n match local/remote references in the input csv.

### 2. Provides the parameters to wgsim and badread in `params.config`
  Allows the user to tweak individual `badread`/`wgsim` parameters in the `params.config` file - instead of the process defintion

let me know if any questions